### PR TITLE
refactor rating input on form to radio buttons

### DIFF
--- a/src/components/forms/bookForm.js
+++ b/src/components/forms/bookForm.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Input, Label, Form
+  Button, Input, Label, Form, FormGroup
 } from 'reactstrap';
 import { createBook, updateBook } from '../../helpers/data/bookData';
 
@@ -74,14 +74,39 @@ export default function BookForm({ setBooks, user, ...bookObj }) {
            >
            </Input>
 
-           <Label>rating</Label>
-           <Input name='rating'
-           type='number'
-           value={book.rating}
-           onChange={handleInputChange}
-           >
-           </Input>
-           <br/>
+           <FormGroup tag="fieldset">
+            <legend>Rating</legend>
+              <FormGroup check>
+                <Label check>
+                  <Input type="radio" name="rating" value='1' checked={book.rating === '1'} onChange={handleInputChange} />
+                  1
+                </Label>
+              </FormGroup>
+              <FormGroup check>
+                <Label check>
+                  <Input type="radio" name="rating" value='2' checked={book.rating === '2'} onChange={handleInputChange} />
+                  2
+                </Label>
+              </FormGroup>
+              <FormGroup check>
+                <Label check>
+                  <Input type="radio" name="rating" value='3' checked={book.rating === '3'} onChange={handleInputChange} />
+                  3
+                </Label>
+              </FormGroup>
+              <FormGroup check>
+                <Label check>
+                  <Input type="radio" name="rating" value='4' checked={book.rating === '4'} onChange={handleInputChange} />
+                  4
+                </Label>
+              </FormGroup>
+              <FormGroup check>
+                <Label check>
+                  <Input type="radio" name="rating" value='5' checked={book.rating === '5'} onChange={handleInputChange} />
+                  5
+                </Label>
+              </FormGroup>
+            </FormGroup>
 
            <Label>Public</Label>
            <Input name='public'


### PR DESCRIPTION
## Description
Refactored rating input on add book form to radio inputs instead of text field. This allows the user to only select a number between 1-5.

## Related Issue
#52 

## Motivation and Context
Closes out Milestone 3, works toward MVP

## How Can This Be Tested?
```git fetch
git checkout radio-buttons
npm i
npm start
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
