### PR TITLE
Book bookshelf bug

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -31,7 +31,13 @@ function App() {
           }
         });
         getBooks().then((booksArray) => setBooks(booksArray));
-        getBookshelves().then((bookshelvesArray) => setBookshelves(bookshelvesArray));
+        getBookshelves().then((bookshelvesArray) => {
+          if (bookshelvesArray !== null) {
+            setBookshelves(bookshelvesArray);
+          } else {
+            console.warn('help');
+          }
+        });
       } else if (user || user === null) {
         setUser(false);
       }

--- a/src/components/BookCard.js
+++ b/src/components/BookCard.js
@@ -1,15 +1,29 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { deleteBook } from '../helpers/data/bookData';
+import { getSingleBookshelfBooksByBookId, deleteBookshelfRel } from '../helpers/data/bookshelfBooksData';
 import BookForm from './forms/bookForm';
 
 export default function BookCard({ setBooks, user, ...book }) {
   const [editing, setEditing] = useState(false);
+  const getAllRels = (taco) => {
+    taco.forEach((i) => {
+      deleteBookshelfRel(i.firebaseKey).then();
+    });
+    deleteBook(book.firebaseKey).then(setBooks);
+  };
 
   const handleClick = (type) => {
     switch (type) {
       case 'delete':
-        deleteBook(book.firebaseKey).then(setBooks);
+        getSingleBookshelfBooksByBookId(book.firebaseKey)
+          .then((resp) => {
+            if (resp.length === 0) {
+              deleteBook(book.firebaseKey).then(setBooks);
+            } else {
+              getAllRels(resp);
+            }
+          });
         break;
       case 'edit':
         setEditing((prevState) => !prevState);

--- a/src/components/BookshelfCard.js
+++ b/src/components/BookshelfCard.js
@@ -3,14 +3,28 @@ import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { deleteBookshelf } from '../helpers/data/bookshelvesData';
 import BookshelfForm from './forms/BookshelfForm';
+import { deleteBookshelfRel, getSingleBookshelfBooks } from '../helpers/data/bookshelfBooksData';
 
 export default function BookshelfCard({ setBookshelves, user, ...bookshelf }) {
   const [editing, setEditing] = useState(false);
   const history = useHistory();
+
+  const getAllRels = (taco) => {
+    taco.forEach((i) => {
+      deleteBookshelfRel(i.firebaseKey).then();
+    });
+    deleteBookshelf(bookshelf.firebaseKey).then(setBookshelves);
+  };
   const handleClick = (type) => {
     switch (type) {
       case 'delete':
-        deleteBookshelf(bookshelf.firebaseKey).then(setBookshelves);
+        getSingleBookshelfBooks(bookshelf.firebaseKey).then((resp) => {
+          if (resp.length === 0) {
+            deleteBookshelf(bookshelf.firebaseKey).then(setBookshelves);
+          } else {
+            getAllRels(resp);
+          }
+        });
         break;
       case 'edit':
         setEditing((prevState) => !prevState);

--- a/src/components/forms/AddBookToShelfForm.js
+++ b/src/components/forms/AddBookToShelfForm.js
@@ -32,8 +32,10 @@ export default function AddBookToShelfForm({ books, setBookshelfBooks }) {
            <Input name='bookId'
            type='select'
            value={bookshelfBook.bookId}
+           placeholder="select a book"
            onChange={handleInputChange}
            >
+          <option value=''>Select a Book</option>
           {books?.map((book) => (
             <option key={book.firebaseKey} value={book.firebaseKey}>
               {book.title} - {book.author}

--- a/src/helpers/data/bookData.js
+++ b/src/helpers/data/bookData.js
@@ -5,8 +5,13 @@ const dbUrl = firebaseConfig.databaseURL;
 
 const getBooks = () => new Promise((resolve, reject) => {
   axios.get(`${dbUrl}/books.json`)
-    .then((response) => resolve(Object.values(response.data)))
-    .catch((error) => reject(error));
+    .then((response) => {
+      if (response.data) {
+        resolve(Object.values(response.data));
+      } else {
+        resolve([]);
+      }
+    }).catch((error) => reject(error));
 });
 
 const createBook = (bookObject) => new Promise((resolve, reject) => {

--- a/src/helpers/data/bookshelfBooksData.js
+++ b/src/helpers/data/bookshelfBooksData.js
@@ -7,8 +7,13 @@ const dbUrl = firebaseConfig.databaseURL;
 
 const getBookshelfBooks = () => new Promise((resolve, reject) => {
   axios.get(`${dbUrl}/bookshelf-books.json`)
-    .then((response) => resolve(Object.values(response.data)))
-    .catch((error) => reject(error));
+    .then((response) => {
+      if (response.data) {
+        resolve(Object.values(response.data));
+      } else {
+        resolve([]);
+      }
+    }).catch((error) => reject(error));
 });
 
 const getSingleBookshelfBooks = (bookshelfId) => new Promise((resolve, reject) => {
@@ -19,6 +24,12 @@ const getSingleBookshelfBooks = (bookshelfId) => new Promise((resolve, reject) =
 
 const getSingleBookshelfBooksByBookId = (firebaseKey) => new Promise((resolve, reject) => {
   axios.get(`${dbUrl}/bookshelf-books.json?orderBy="bookId"&equalTo="${firebaseKey}"`)
+    .then((response) => resolve(Object.values(response.data)))
+    .catch((error) => reject(error));
+});
+
+const getSingleBookshelfBookRel = (firebaseKey) => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/bookshelf-books/${firebaseKey}.json`)
     .then((response) => resolve(Object.values(response.data)))
     .catch((error) => reject(error));
 });
@@ -72,6 +83,7 @@ export {
   deleteBookshelfRel,
   getSingleBookshelfBooks,
   getSingleBookshelfBooksByBookId,
+  getSingleBookshelfBookRel,
   mergeBooksAndShelves,
   mergeBooksAndSingleShelf
 };

--- a/src/helpers/data/bookshelvesData.js
+++ b/src/helpers/data/bookshelvesData.js
@@ -5,8 +5,13 @@ const dbUrl = firebaseConfig.databaseURL;
 
 const getBookshelves = () => new Promise((resolve, reject) => {
   axios.get(`${dbUrl}/bookshelves.json`)
-    .then((response) => resolve(Object.values(response.data)))
-    .catch((error) => reject(error));
+    .then((response) => {
+      if (response.data) {
+        resolve(Object.values(response.data));
+      } else {
+        resolve([]);
+      }
+    }).catch((error) => reject(error));
 });
 
 const createBookshelf = (bookshelfObject) => new Promise((resolve, reject) => {

--- a/src/views/BookshelvesView.js
+++ b/src/views/BookshelvesView.js
@@ -4,17 +4,23 @@ import BookshelfForm from '../components/forms/BookshelfForm';
 import BookshelfCard from '../components/BookshelfCard';
 
 export default function BookshelvesView({ bookshelves, setBookshelves, user }) {
+  const getBookshelfCards = () => (
+    bookshelves.map((bookshelf) => (
+      <BookshelfCard key={bookshelf.firebaseKey}
+      setBookshelves={setBookshelves}
+      {...bookshelf}
+      />
+    ))
+  );
   return (
     <div>
       <h1>this is the bookshelves view</h1>
       <BookshelfForm setBookshelves={setBookshelves} user={user}/>
       <div className='flex flex-row flex-wrap'>
-      {bookshelves.map((bookshelf) => (
-        <BookshelfCard key={bookshelf.firebaseKey}
-        setBookshelves={setBookshelves}
-        {...bookshelf}
-        />
-      ))}
+        { bookshelves != null
+          ? getBookshelfCards()
+          : <h2>please add a bookshelf</h2>
+      }
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
Added functionality so that when a user deletes a book, the bookshelf-book relationships delete, and when a user deletes a bookshelf, the bookshelf-book relationships delete. 

Changed get[data] calls to account for no data so as to not break the whole app.

## Related Issue
#65 

## Motivation and Context
solves the problem of a bunch of unnecessary data in the database. Removes unused join tables. Prevent user from breaking app with no data.

## How Can This Be Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
