### PR TITLE
fixed bug that allowed user to add book to shelf more than once

### DIFF
--- a/src/components/forms/AddBookToShelfForm.js
+++ b/src/components/forms/AddBookToShelfForm.js
@@ -4,7 +4,7 @@ import {
   Button, Form, Input, Label
 } from 'reactstrap';
 import { useParams } from 'react-router-dom';
-import { createBookshelfBooks } from '../../helpers/data/bookshelfBooksData';
+import { createBookshelfBooks, getSingleBookshelfBooksByBookId } from '../../helpers/data/bookshelfBooksData';
 
 export default function AddBookToShelfForm({ books, setBookshelfBooks }) {
   const { firebaseKey } = useParams();
@@ -13,9 +13,20 @@ export default function AddBookToShelfForm({ books, setBookshelfBooks }) {
     bookId: ''
   });
 
+  const bookChecker = () => {
+    getSingleBookshelfBooksByBookId(bookshelfBook.bookId).then((resp) => {
+      const result = resp.filter((i) => i.bookshelfId === firebaseKey);
+      if (result.length >= 1) {
+        console.warn('already added');
+      } else {
+        createBookshelfBooks(bookshelfBook).then(setBookshelfBooks);
+      }
+    });
+  };
+
   const handleSubmit = (e) => {
     e.preventDefault();
-    createBookshelfBooks(bookshelfBook).then(setBookshelfBooks);
+    bookChecker();
   };
 
   const handleInputChange = (e) => {


### PR DESCRIPTION
## Description
Added logic to bookshelf book relationship form to check if a book already exists on that shelf. If it doesn't, that book is added. If it does, nothing happens.

## Related Issue
#67 

## Motivation and Context
keeps user from adding a book to a single shelf more than once. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
